### PR TITLE
allow disabling test alarm handling

### DIFF
--- a/app/src/main/java/com/github/frimtec/android/pikettassist/receiver/SmsListener.java
+++ b/app/src/main/java/com/github/frimtec/android/pikettassist/receiver/SmsListener.java
@@ -53,7 +53,7 @@ public class SmsListener extends BroadcastReceiver {
           Log.i(TAG, "SMS from pikett number");
           Pattern testSmsPattern = Pattern.compile(SharedState.getSmsTestMessagePattern(context), Pattern.DOTALL);
           Matcher matcher = testSmsPattern.matcher(sms.getText());
-          if (matcher.matches()) {
+          if (SharedState.getTestAlarmEnabled(context) && matcher.matches()) {
             String id = matcher.groupCount() > 0 ? matcher.group(1) : null;
             id = id != null ? id : context.getString(R.string.test_alarm_context_general);
             Log.i(TAG, "TEST alarm with ID: " + id);

--- a/app/src/main/java/com/github/frimtec/android/pikettassist/state/SharedState.java
+++ b/app/src/main/java/com/github/frimtec/android/pikettassist/state/SharedState.java
@@ -32,6 +32,7 @@ public final class SharedState {
   public static final String PREF_KEY_TEST_ALARM_MESSAGE_PATTERN = "test_alarm_message_pattern";
   public static final String PREF_KEY_TEST_ALARM_CHECK_TIME = "test_alarm_check_time";
   public static final String PREF_KEY_TEST_ALARM_CHECK_WEEKDAYS = "test_alarm_check_weekdays";
+  public static final String PREF_KEY_TEST_ALARM_ENABLED = "test_alarm_enabled";
   public static final String PREF_KEY_TEST_ALARM_ACCEPT_TIME_WINDOW_MINUTES = "test_alarm_accept_time_window_minutes";
   public static final String PREF_KEY_SMS_CONFIRM_TEXT = "sms_confirm_text";
   public static final String PREF_KEY_SMS_ADAPTER_SECRET = "sms_adapter_secret";
@@ -135,6 +136,11 @@ public final class SharedState {
     SharedPreferences.Editor editor = preferences.edit();
     editor.putBoolean(PREF_KEY_PIKETT_STATE_MANUALLY_ON, manuallyOn);
     editor.apply();
+  }
+
+  public static boolean getTestAlarmEnabled(Context context) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    return preferences.getBoolean(PREF_KEY_TEST_ALARM_ENABLED, true);
   }
 
   public static String getAlarmRingTone(Context context) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -29,6 +29,7 @@
     <string name="pref_default_test_alarm_message_pattern">--- UNDEFINIERT ---</string>
     <string name="pref_title_supervise_test_contexts">Überwachte Testkontexte</string>
     <string name="pref_title_test_alarm_check_time">Überwachungszeitpunkt</string>
+    <string name="pref_title_test_alarm_enabled">Testalarme verarbeiten</string>
     <string name="pref_default_test_alarm_check_time">12:00</string>
     <string name="pref_title_test_alarm_accept_time_window_minutes">Testalarm Zeitfenster (Minuten)</string>
     <string name="pref_default_test_alarm_accept_time_window_minutes">15</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="pref_default_test_alarm_message_pattern">--- UNDEFINED ---</string>
     <string name="pref_title_supervise_test_contexts">Test contexts to supervise</string>
     <string name="pref_title_test_alarm_check_time">Check time</string>
+    <string name="pref_title_test_alarm_enabled">Handle test alarm messages</string>
     <string name="pref_default_test_alarm_check_time">12:00</string>
     <string name="pref_title_test_alarm_accept_time_window_minutes">Test alarm time window (minutes)</string>
     <string name="pref_default_test_alarm_accept_time_window_minutes">15</string>

--- a/app/src/main/res/xml/pref_test_alarm.xml
+++ b/app/src/main/res/xml/pref_test_alarm.xml
@@ -1,4 +1,9 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <SwitchPreference
+        android:defaultValue="true"
+        android:icon="@drawable/ic_test_alarm"
+        android:key="test_alarm_enabled"
+        android:title="@string/pref_title_test_alarm_enabled" />
 
     <EditTextPreference
         android:defaultValue="@string/pref_default_test_alarm_message_pattern"


### PR DESCRIPTION
This PR should allow disabling the test alarm handling.

Disabling this feature might be useful, if no test alarms are expected, and if the content of the message is not known.