### PR TITLE
Disable hanging crash report on android 14

### DIFF
--- a/app/src/main/java/com/github/frimtec/android/pikettassist/PAssistApplication.java
+++ b/app/src/main/java/com/github/frimtec/android/pikettassist/PAssistApplication.java
@@ -50,7 +50,9 @@ public class PAssistApplication extends Application {
   @Override
   public void onCreate() {
     super.onCreate();
-    Thread.setDefaultUncaughtExceptionHandler(this::handleUncaughtException);
+    if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      Thread.setDefaultUncaughtExceptionHandler(this::handleUncaughtException);
+    }
     openHelper = new DbHelper(this);
     getWritableDatabase().execSQL("PRAGMA foreign_keys=ON;");
     keyValueStore = new KeyValueStore(new KeyValueDao(DbFactory.instance()));


### PR DESCRIPTION
The crash report feature does hang forever on android 14. 
Therefore doing nothing is better and let the app crash immediately.