### PR TITLE
Remove unused permission WRITE_EXTERNAL_STORAGE

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:maxSdkVersion="27" android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:maxSdkVersion="28" android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
         android:name=".PAssistApplication"

--- a/app/src/main/java/com/github/frimtec/android/pikettassist/service/system/Feature.java
+++ b/app/src/main/java/com/github/frimtec/android/pikettassist/service/system/Feature.java
@@ -80,22 +80,6 @@ public enum Feature {
       }
     }
   },
-  PERMISSION_WRITE_EXTERNAL_STORAGE(
-      true,
-      true,
-      R.string.permission_write_external_storage_title,
-      context -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q || allPermissionsGranted(context, PermissionSets.WRITE_EXTERNAL_STORAGE.getPermissions())
-  ) {
-    @Override
-    public void request(Context context) {
-      requestPermissionsWithExplanation(
-          context,
-          PermissionSets.WRITE_EXTERNAL_STORAGE.getPermissions(),
-          R.string.permission_write_external_storage_title,
-          R.string.permission_write_external_storage_text
-      );
-    }
-  },
   PERMISSION_COARSE_LOCATION(
       true,
       true,
@@ -284,7 +268,6 @@ public enum Feature {
     CONTACTS_READ(Collections.singleton(Manifest.permission.READ_CONTACTS)),
     CALENDAR_READ(Collections.singleton(Manifest.permission.READ_CALENDAR)),
     @RequiresApi(api = 33) POST_NOTIFICATIONS(Collections.singleton(Manifest.permission.POST_NOTIFICATIONS)),
-    WRITE_EXTERNAL_STORAGE(Collections.singleton(Manifest.permission.WRITE_EXTERNAL_STORAGE)),
     COARSE_LOCATION(Collections.singleton(Manifest.permission.ACCESS_COARSE_LOCATION)),
     NON_CRITICAL(
         Set.of(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -137,8 +137,6 @@
   <string name="permission_contacts_text">PAssist liest den konfigurierten Kontakt der Alarmierungszentrale, um zu ermitteln, von welcher Telefonnummer die zu überwachenden SMS gesendet werden. Ohne dieses Recht ist PAssist nicht funktionsfähig!</string>
   <string name="permission_calendar_title">Kalender</string>
   <string name="permission_calendar_text">PAssist liest den Kalender, um die Zeitfenster zu ermitteln, in denen der Bereitschaftsdienst stattfindet. Nur bei aktivem Bereitschaftsdienst ist die Überwachungsfunktion von PAssist aktiv. Ohne dieses Recht ist PAssist nicht funktionsfähig!</string>
-  <string name="permission_write_external_storage_title">Externen Speicher</string>
-  <string name="permission_write_external_storage_text">Um einen SMS-Adapter herunterzuladen zu können, sowie das Erstellen von Backups der Alarmhistorie ist es notwendig, dass PAssist auf den externen Speicher schreiben darf.</string>
   <string name="permission_location_title">Position</string>
   <string name="permission_location_text">Um die Telefonempfangsqualität während des Bereitschaftsdienstes zu überwachen, muss auf die Telefonzelleninformation zugegriffen werden. Diese Daten werden mit dem Recht Gerätestandort geschützt, da mit diesen Daten auch die grobe Position ermittelt werden könnte. Ohne dieses Recht ist PAssist nicht funktionsfähig!</string>
   <string name="send_log_title">PAssist Crash-Report</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -139,8 +139,6 @@
   <string name="permission_contacts_text">PAssist lit le numéro de téléphone du contact du centre d\'opérations configuré. Ceci est utilisé pour décider quel SMS doit être supervisé pendant l\'astreinte. Sans cette autorisation, PAssist ne fonctionne pas!</string>
   <string name="permission_calendar_title">Calendrier</string>
   <string name="permission_calendar_text">PAssist lit les événements du calendrier pour déterminer si l\'astreinte est active ou non. Uniquement dans un état d\'astreinte actif, les fonctions de supervision de PAssist sont activées. Sans cette autorisation, PAssist ne fonctionne pas!</string>
-  <string name="permission_write_external_storage_title">Stockage externe</string>
-  <string name="permission_write_external_storage_text">Pour télécharger un adaptateur SMS et stocker des sauvegardes de l\'historique des alarmes, il est nécessaire que PAssist puisse écrire sur le stockage externe.</string>
   <string name="permission_location_title">Emplacement</string>
   <string name="permission_location_text">Pour superviser la force du signal téléphonique pendant le service de garde, PAssist doit accéder aux informations des cellules téléphoniques à portée. Ces données sont protégées par la permission localisation grossière. Sans cette autorisation, PAssist ne fonctionne pas!</string>
   <string name="send_log_title">Rapport de plantage PAssist</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -138,8 +138,6 @@
   <string name="permission_contacts_text">PAssist legge il numero di telefono dal contatto della centrale operativa configurata. Viene utilizzato per decidere quale SMS deve essere supervisionato durante il servizio di guardia. PAssist non funziona senza questa autorizzazione!</string>
   <string name="permission_calendar_title">Calendario</string>
   <string name="permission_calendar_text">PAssist legge gli eventi dal calendario per determinare se il servizio di guardia è attivo o meno. Solo in uno stato di chiamata attivo, le funzioni di supervisione di PAssist sono abilitate. PAssist non funziona senza questa autorizzazione!</string>
-  <string name="permission_write_external_storage_title">Archiviazione esterna</string>
-  <string name="permission_write_external_storage_text">Per scaricare un adattatore SMS e memorizzare i backup della cronologia allarmi, è necessario che PAssist possa scrivere nella memoria esterna.</string>
   <string name="permission_location_title">Posizione</string>
   <string name="permission_location_text">Per controllare la potenza del segnale del telefono durante il servizio di guardia, PAssist deve accedere alle informazioni dalle celle del telefono nel raggio d\'azione. Questi dati sono protetti dalla posizione grossolana dell\'autorizzazione. PAssist non funziona senza questa autorizzazione!</string>
   <string name="send_log_title">Rapporto sull\'arresto anomalo di PAssist</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,8 +147,6 @@
   <string name="permission_contacts_text">PAssist reads the phone number from the contact of the configured operations center. This is used to decide which SMS must be supervised during on-call duty. Without this permission PAssist does not work!</string>
   <string name="permission_calendar_title">Calendar</string>
   <string name="permission_calendar_text">PAssist reads the events from the calendar to determine whether on-call duty is active or not. Only in an active on-call state, the supervise functions of PAssist are enabled. Without this permission PAssist does not work!</string>
-  <string name="permission_write_external_storage_title">External storage</string>
-  <string name="permission_write_external_storage_text">To download an SMS adapter and to store backups of the alarm history, it is required that PAssist can write to the external storage.</string>
   <string name="permission_location_title">Location</string>
   <string name="permission_location_text">To supervise the phone signal strength during on-call duty, PAssist must access information from the phone cells in range. This data is protected by the permission coarse location. Without this permission PAssist does not work!</string>
   <string name="send_log_title">PAssist crash report</string>


### PR DESCRIPTION
As of discussion of in  https://github.com/frimtec/pikett-assist/issues/508 it turned out that the permission WRITE_EXTERNAL_STORAGE is not needed anymore and therefor will be dropped.