### PR TITLE
Bump com.github.frimtec:secure-sms-proxy-api from 3.5.0 to 3.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The SMS received from any phone number of this contact are supervised by PAssist
 PAssist also supports operations centers using numeric and alphanumeric short code SMS numbers.
 Numeric short codes are currently only supported for the following countries:
 
+* Australia (AU) - as of release 2.18.1 and S2MSP release 3.5.2
 * Belgium (BE)
 * Botswana (BW)
 * Brazil (BR)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "de.mannodermaus.android-junit5"
 apply plugin: 'jacoco'
 
 // Third party library versions
-def secure_sms_proxy_api_version = '3.5.0'
+def secure_sms_proxy_api_version = '3.5.2'
 def android_billingclient_version = '8.0.0'
 def slidetoact_version = '0.11.0'
 def takisoft_preferencex_version = '1.1.0'


### PR DESCRIPTION
Support numeric short codes for Australia