### PR TITLE
Bump down com.google.android.material:material from 1.13.0 to 1.12.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation fileTree(include: ['*.jar', '*.aar'], dir: 'lib')
     implementation "androidx.work:work-runtime:$work_version"
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'com.vdurmont:semver4j:3.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.google.code.gson:gson:2.13.2'


### PR DESCRIPTION
com.google.android.material:material 1.13.0 triggers a malware alarm by Ikarus and Google VT-Checks