### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -106,6 +106,8 @@ jobs:
 
   update-repo:
 
+    permissions:
+      contents: write
     runs-on: ubuntu-22.04
     needs: deploy
 


### PR DESCRIPTION
Potential fix for [https://github.com/frimtec/pikett-assist/security/code-scanning/4](https://github.com/frimtec/pikett-assist/security/code-scanning/4)

To fix the problem, we need to add an explicit `permissions` block to the `update-repo` job (the one beginning at line 108) in `.github/workflows/deploy_release.yml`. Examining the steps, we see that this job uses both `actions/checkout@v5` and commits and pushes to the repository; these both require the workflow to have write access to contents (`contents: write`). Therefore, the correct fix is to add:
```yaml
permissions:
  contents: write
```
directly under the job’s name (before `runs-on`). No other permissions are needed unless there is a step requiring them (not apparent here). No code or method changes are required elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
